### PR TITLE
Review step 4 (fluid simulation)

### DIFF
--- a/fsi-workflow/03_fluidMesh/tasks.md
+++ b/fsi-workflow/03_fluidMesh/tasks.md
@@ -179,9 +179,7 @@ When finished, you will see three time folders (0.001, 0.002, 0.003) in the root
 
 Notes:
 - the timestep depends on the `deltaT` parameter in the `controlDict` file, but it is not relevant
-- you can obtain the final mesh in the `constant` directory, without the intermediate steps, by adding the `-overwrite` option to `snappyHexMesh`
-
-**TODO:** We probably want to explicitly tell people to use the `-overwrite`, right? Or is that not needed?
+- you can obtain the final mesh in the `constant` directory, without the intermediate steps, by adding the `-overwrite` option to `snappyHexMesh`. In the next step (fluid simulation), we will use the `0.003` directory.
 
 ## checkMesh
 

--- a/fsi-workflow/04_fluidSimulation/skeleton/Fluid/system/controlDict
+++ b/fsi-workflow/04_fluidSimulation/skeleton/Fluid/system/controlDict
@@ -47,8 +47,6 @@ timePrecision   6;
 runTimeModifiable true;
 
 adjustTimeStep  no;
-maxCo           4;
-maxDeltaT       0.01;
 
 // ************************************************************************* //
 

--- a/fsi-workflow/04_fluidSimulation/skeleton/run_case.sh
+++ b/fsi-workflow/04_fluidSimulation/skeleton/run_case.sh
@@ -5,7 +5,7 @@ cd Fluid
 cp -r 0.orig 0
 
 decomposePar
-#mpirun -np 8 renumberMesh -overwrite -parallel | tee log.renumberMesh
-mpirun -np 8 simpleFoam -parallel | tee log.solver
+#mpirun -np 8 -oversubscribe renumberMesh -overwrite -parallel | tee log.renumberMesh
+mpirun -np 8 -oversubscribe simpleFoam -parallel | tee log.solver 2>&1
 reconstructPar -latestTime
 

--- a/fsi-workflow/04_fluidSimulation/tasks.md
+++ b/fsi-workflow/04_fluidSimulation/tasks.md
@@ -8,7 +8,7 @@ This will allow us to perform two important tasks:
 
 ## Introduction
 
-We want an initialized fluid domain, so we can simply perform a **steady state** simulation.
+We want an initialized fluid domain, so we can simply perform a **steady state** simulation. Later, in the FSI part, we will switch to a transient simulation.
 
 You'll find the required files in the `skeleton` directory. The `Fluid` directory is the OpenFOAM root case, containing the `constant`, `system` and
 `0.orig` folders. We put everything into the `Fluid` directory to familiarize with the fact that we'll soon have a `Fluid` and a `Solid` case.
@@ -25,9 +25,9 @@ You'll find the required files in the `skeleton` directory. The `Fluid` director
 
 Here we consider a laminar incompressible simulation in water. The main parameters are:
 
-- $U_{\infty} = 0.5$
-- $\rho = 1000$
-- $\nu = 1 \cdot 10^{-6}$
+- $U_{\infty} = 0.5 \ \mathrm{m/s}$
+- $\rho = 1000 \ \mathrm{kg/m^3}$
+- $\nu = 1 \cdot 10^{-6} \ \mathrm{m^2/s}$
 - $Re = \frac{U_{\infty} c}{\nu} = 5 \cdot 10^4$
 
 ### `0.orig` folder
@@ -39,13 +39,13 @@ Open the file `U` and:
 - substitute **UINF** at line 19 with the value **0.5**. This initializes the whole domain to $U_{\infty}$
 - substitute the boundary condition **BOUNDARY** for the *naca2312* patch at line **28** with **noSlip**
 
-Note: we use the folder `0.orig` instead of the usual folder `0` just in case the simulation overwrites the initial conditions (e.g. you perform `potentialFoam` to initialize the fluid domain). The launch script that we prepared will take care of copying `0.orig` to `0`.
+Note: we use the folder `0.orig` instead of the usual folder `0` just in case the simulation overwrites the initial conditions (e.g., you execute `potentialFoam` to initialize the fluid domain). The launch script that we prepared will take care of copying `0.orig` to `0`.
 
 ### `constant` folder
 
 Here you need to perform the following activities:
 
-- Use the **mesh** you generated in the previous task: copy the `polyMesh` folder, that you find in the `0.003` folder, in here
+- Use the **mesh** you generated in the previous task: copy the `polyMesh` folder, which you can find in the `0.003` folder, in here
 - Open the `transportProperties` file to define the kinematic viscosity $\nu$: substitute **NU** at line **19** with `1e-06`
 - Open the `turbulenceProperties` file to define the type of simulation: uncomment line **17** to perform a **laminar** simulation
 
@@ -53,11 +53,11 @@ Here you need to perform the following activities:
 
 Here you will define how many simulation steps you want to perform and you will make use of *function objects* in order to compute **forces, moments** and **force** and **moment coefficients**:
 
-- Open the `controlDict` file and:
+- Open the `controlDict` file and orientate yourself on the different sections. Then:
     1. substitute **END** with **500** at line **26**: we will perform 500 simulation steps at most
     2. substitute **RHO** with **1000.0** at lines **77** and **102**
     3. substitute **UINF** with **0.2** at line **111**
-    4. substitute **CHORD** with **0.1**at line **112**
+    4. substitute **CHORD** with **0.1** at line **112**
     5. substitute **AREA** with **0.03** at line **113**
 
 Then you will define the type of the simulation and some thresholds for the residuals so that, if we reach those values, the simulation stops before *endTime*:
@@ -76,38 +76,40 @@ In order to run simulation, open a terminal from the `skeleton` folder, source O
 - running `simpleFoam` in parallel and logging the output in `log.solver`
 - reconstucting the latest timeStep
 
-## Monitoring
+By default, the script is running the case with 8 processes, using oversubscription. You can change the partitioning by changing the `system/decomposeParDict` and you then change the number of processes in `run_case.sh`.
 
-(**TODO** check if available)
+The simulation will probably take around 5-10 min to complete all 500 iterations. You can get a pretty much converged state earlier (e.g., around 300 iterations).
+
+## Monitoring
 
 To check the simulation progress and plot the residuals over time, you can:
 
 - open another terminal
 - go to the `Fluid` folder
 - source OpenFOAM
-- type `pyFoamPlotWatcher log.solver`
+- type `pyFoamPlotWatcher log.solver` (requires [PyFoam](https://pypi.org/project/PyFoam/))
 
-## Analysis of the results
+## Analyzing the results
 
-In order to understand if your simulation has converged and if you have obtained reasonable results, you can look at the output of the `function objects` that we enabled in the `controlDict` dictionary.
+In order to understand if your simulation has converged and if you have obtained reasonable results, you can look at the output of the `functions` that we enabled in the `controlDict` dictionary.
 
 You can plot force coefficients over time by typing in the case root folder:
 
 `python3 plotCoefficients.py`
 
-You should see something like:
+You should see something like: (**TODO: Check**)
 
 ![CdCl](./images/cdcl.png)
 
-You can compare those values with theoretical data (if you have them), or you can perform some *mesh independence study* to check the convergence of your setup.
+You can compare those values with theoretical data (if you have them), or you can perform some *mesh independence study* to check the convergence of your setup. But for the sake of time, let's move on to the FSI part.
 
 ## Setup *Simulation 2* (optional)
 
 Now we consider a laminar incompressible simulation in air, with the same Reynolds number. The main parameters are:
 
-- $U_{\infty} = 7.5$
-- $\rho = 1.225$
-- $\nu = 1.5 \cdot 10^{-5}$
+- $U_{\infty} = 7.5\ \mathrm{m/s}$
+- $\rho = 1.225 \ \mathrm{kg/m^3}$
+- $\nu = 1.5 \cdot 10^{-5}\ \mathrm{m^2/s}$
 - $Re = \frac{U_{\infty} c}{\nu} = 5 \cdot 10^4$
 
 You have to:


### PR DESCRIPTION
Regarding the option vs water (simulation 1) and air (simulation 2):
- water took 545s (9 min)
- air took 770s (13min)
I need to check how this works in the FSI case as well. I would suggest anyway to only guide the participants to simulate one predefined setup. Having the other one as optional at the end (as already is the case) is fine.

I am wondering if we really need 500 iterations here. We could save precious time if we ended earlier (e.g., at 300, which at least for the water seems to be fine).