### PR TITLE
First review of step 5 (FSI)

### DIFF
--- a/fsi-workflow/05_FSI/skeleton/Fluid/run_fluid.sh
+++ b/fsi-workflow/05_FSI/skeleton/Fluid/run_fluid.sh
@@ -2,4 +2,4 @@
 cd ${0%/*} || exit 1    		    		# Run from this directory
 . $WM_PROJECT_DIR/bin/tools/RunFunctions    # Tutorial run functions
 
-mpirun -np 8 pimpleFoam -parallel | tee log.pimpleFoam 2>&1
+mpirun -np 8 --oversubscribe pimpleFoam -parallel | tee log.pimpleFoam 2>&1


### PR DESCRIPTION
See some new TODOs with suggestions for simplification in `tasks.md`.

It looks like the case is currently missing a `0.orig/pointDisplacement` file. I did not yet run it. I guess you already have the `pointDisplacement` file for this case, the question is how to guide the user to use that. Maybe provide it already in task 4?

Generally, we could save some time by reusing more files from previous steps.