### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,13 +9,10 @@ jobs:
     steps:
     - name: Check out repository
       uses: actions/checkout@v4
-    - name: Setup python
-      uses: actions/setup-python@v5
-      with:
-         python-version: '3.x'
     - name: Prepare system
       run: |
-        python3 -m venv .venv && source .venv/bin/activate
+        apt-get update && apt-get install -y python3-venv
+        python3 -m venv .venv && . .venv/bin/activate
         pip install poppler-utils pandoc-fignos
     - name: Build
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,12 @@ jobs:
     steps:
     - name: Check out repository
       uses: actions/checkout@v4
+    - name: Setup python
+      uses: actions/setup-python@v5
+      with:
+         python-version: '3.x'
     - name: Prepare system
       run: |
-        apt-get update && apt-get install -y python3-venv
         python3 -m venv .venv && source .venv/bin/activate
         pip install poppler-utils pandoc-fignos
     - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: tumi5/latex
+    container: texlive/texlive:TL2021-historic
     steps:
     - name: Check out repository
       uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
       run: |
         apt-get update && apt-get install -y python3-venv
         python3 -m venv .venv && . .venv/bin/activate
+        echo PATH=$PATH >> $GITHUB_ENV
         pip install poppler-utils pandoc-fignos
     - name: Build
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,8 @@ jobs:
       uses: actions/checkout@v4
     - name: Prepare system
       run: |
-        apt-get update && apt-get install -y poppler-utils
-        pip install pandoc-fignos
+        python3 -m venv .venv && source .venv/bin/activate
+        pip install poppler-utils pandoc-fignos
     - name: Build
       run: |
         cd fsi-workflow && make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
         echo PATH=$PATH >> $GITHUB_ENV
         pip install poppler-utils
         # Workaround for https://github.com/tomduck/pandoc-xnos/pull/29
+        apt-get install -y git
         pip install --force-reinstall git+https://github.com/nandokawka/pandoc-xnos@284474574f51888be75603e7d1df667a0890504d#egg=pandoc-xnos
     - name: Build
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: texlive/texlive:TL2021-historic
+    container: texlive/texlive:latest
     steps:
     - name: Check out repository
       uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,9 @@ jobs:
         apt-get update && apt-get install -y python3-venv
         python3 -m venv .venv && . .venv/bin/activate
         echo PATH=$PATH >> $GITHUB_ENV
-        pip install poppler-utils pandoc-fignos
+        pip install poppler-utils
+        # Workaround for https://github.com/tomduck/pandoc-xnos/pull/29
+        pip install --force-reinstall git+https://github.com/nandokawka/pandoc-xnos@284474574f51888be75603e7d1df667a0890504d#egg=pandoc-xnos
     - name: Build
       run: |
         cd fsi-workflow && make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: texlive/texlive:latest
+    container: tumi5/latex
     steps:
     - name: Check out repository
       uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,10 @@ jobs:
       uses: actions/checkout@v4
     - name: Prepare system
       run: |
-        apt-get update && apt-get install -y python3-venv
+        apt-get update && apt-get install -y python3-venv poppler-utils
         python3 -m venv .venv && . .venv/bin/activate
         echo PATH=$PATH >> $GITHUB_ENV
-        pip install poppler-utils pandoc-fignos
+        pip install pandoc-fignos
         # Workaround for https://github.com/tomduck/pandoc-xnos/pull/29
         apt-get install -y git
         pip install --force-reinstall git+https://github.com/nandokawka/pandoc-xnos@284474574f51888be75603e7d1df667a0890504d#egg=pandoc-xnos

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         apt-get update && apt-get install -y python3-venv
         python3 -m venv .venv && . .venv/bin/activate
         echo PATH=$PATH >> $GITHUB_ENV
-        pip install poppler-utils
+        pip install poppler-utils pandoc-fignos
         # Workaround for https://github.com/tomduck/pandoc-xnos/pull/29
         apt-get install -y git
         pip install --force-reinstall git+https://github.com/nandokawka/pandoc-xnos@284474574f51888be75603e7d1df667a0890504d#egg=pandoc-xnos

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
       uses: actions/checkout@v4
     - name: Prepare system
       run: |
+        apt-get update && apt-get install -y python3-venv
         python3 -m venv .venv && source .venv/bin/activate
         pip install poppler-utils pandoc-fignos
     - name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/
+.venv/
 *.pdf


### PR DESCRIPTION
Currently [failing](https://github.com/precice/community-training/actions/runs/16703922552/job/47279222566?pr=24) with:

```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
```

Switches the installation of some dependencies to PIP instead of APT.